### PR TITLE
Fix brew deprecation warning

### DIFF
--- a/Formula/elasticsearch@6.4.rb
+++ b/Formula/elasticsearch@6.4.rb
@@ -12,7 +12,7 @@ class ElasticsearchAT64 < Formula
 
   bottle :unneeded
 
-  depends_on :java => "1.8"
+  depends_on "openjdk@8"
 
   def cluster_name
     "elasticsearch_#{ENV["USER"]}"


### PR DESCRIPTION
```
Warning: Calling depends_on :java is deprecated! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
Please report this issue to the range-me/versions tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/range-me/homebrew-versions/Formula/elasticsearch@6.4.rb:15
```